### PR TITLE
Update index.html

### DIFF
--- a/WinterCricketUI - Copy/WinterCricketUI/index.html
+++ b/WinterCricketUI - Copy/WinterCricketUI/index.html
@@ -75,7 +75,7 @@
 </head>
 
 <body class="container">
-        <div ng-include="'/app/UI/home.html'"></div>
+        <div ng-include="'app/UI/home.html'"></div>
 </body>
 
 </html>


### PR DESCRIPTION
removed extra slash from ng-include for home page. This works fine for local system but not for the deployed one. IIS does not find home.html with this way.